### PR TITLE
[Issue#18] trx->serialised should be initialized.

### DIFF
--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -1244,6 +1244,7 @@ static void trx_start_low(
   read_view_open_now: */
 
   trx->no = TRX_ID_MAX;
+  trx->serialised = false;
 
   ut_a(ib_vector_is_empty(trx->lock.autoinc_locks));
   ut_a(trx->lock.table_locks.empty());


### PR DESCRIPTION
[Issue#18](https://github.com/kunpengcompute/mysql-server/issues/18) 在trx_start_low时初始化trx->serialised