### PR TITLE
[Issue#7] Use AArch64 word_add_fetch in rw_lock_lock_word_incr

### DIFF
--- a/storage/innobase/CMakeLists.txt
+++ b/storage/innobase/CMakeLists.txt
@@ -138,6 +138,7 @@ SET(INNOBASE_SOURCES
   lock/lock0guards.cc
   lock/lock0iter.cc
   lock/lock0prdt.cc
+  lock/lock0aarch64_atomic.cc
   lock/lock0latches.cc
   lock/lock0lock.cc
   lock/lock0wait.cc
@@ -264,3 +265,8 @@ IF(HAS_WARN_FLAG)
   ADD_COMPILE_FLAGS(fts/fts0pars.cc
     COMPILE_FLAGS "${HAS_WARN_FLAG}")
 ENDIF()
+
+ADD_COMPILE_FLAGS(
+  lock/lock0aarch64_atomic.cc
+  COMPILE_FLAGS "-march=armv8-a+lse"
+)

--- a/storage/innobase/include/lock0aarch64_atomic.h
+++ b/storage/innobase/include/lock0aarch64_atomic.h
@@ -1,0 +1,8 @@
+#ifndef lock0aarch64_atomic_h
+#define lock0aarch64_atomic_h
+
+#include "univ.i"
+
+lint word_add_fetch(volatile lint *word, ulint amount);
+
+#endif /* lock0aarch64_atomic_h */

--- a/storage/innobase/include/sync0rw.ic
+++ b/storage/innobase/include/sync0rw.ic
@@ -38,6 +38,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
  *******************************************************/
 
 #include "os0event.h"
+#include "lock0aarch64_atomic.h"
 
 /** Lock an rw-lock in shared mode for the current thread. If the rw-lock is
  locked in exclusive mode, or there is an exclusive lock request waiting,
@@ -259,7 +260,7 @@ lint rw_lock_lock_word_incr(rw_lock_t *lock, /*!< in/out: rw-lock */
                             ulint amount)    /*!< in: amount of increment */
 {
 #ifdef INNODB_RW_LOCKS_USE_ATOMICS
-  return (os_atomic_increment_lint(&lock->lock_word, amount));
+  return word_add_fetch(&lock->lock_word, amount);
 #else  /* INNODB_RW_LOCKS_USE_ATOMICS */
   lint local_lock_word;
 

--- a/storage/innobase/lock/lock0aarch64_atomic.cc
+++ b/storage/innobase/lock/lock0aarch64_atomic.cc
@@ -1,0 +1,12 @@
+#include "lock0aarch64_atomic.h"
+
+lint word_add_fetch(volatile lint *word, ulint amount) {
+  asm volatile (
+    "ldaddal %0, x3, [%1]\n\t"
+    "add %0, x3, %0"
+      :"+r"(amount)
+      :"r"(word)
+      :"x3","memory"
+  );
+  return amount;
+}


### PR DESCRIPTION
[Issue#7](https://github.com/kunpengcompute/mysql-server/issues/7) 在释放rwlock时启用LSE中ldaddal指令