### PR TITLE
[Issue#28] Clean up recovered transactions of state TRX_STATE_COMMITTED_IN_MEMORY

### DIFF
--- a/storage/innobase/include/trx0roll.h
+++ b/storage/innobase/include/trx0roll.h
@@ -64,10 +64,10 @@ trx_undo_rec_t *trx_roll_pop_top_rec_of_trx(
 /** Rollback or clean up any incomplete transactions which were
  encountered in crash recovery.  If the transaction already was
  committed, then we clean up a possible insert undo log. If the
- transaction was not yet committed, then we roll it back.
- @param all true=roll back all recovered active transactions;
- false=roll back any incomplete dictionary transaction */
-void trx_rollback_recovered(bool all);
+ transaction was not yet committed, then we roll it back. */
+void trx_rollback_or_clean_recovered(
+    ibool all); /*!< in: FALSE=roll back dictionary transactions;
+                TRUE=roll back all non-PREPARED transactions */
 
 /** Rollback or clean up any incomplete transactions which were
 encountered in crash recovery.  If the transaction already was

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -99,9 +99,9 @@ trx_t *trx_allocate_for_background(void);
 /** Resurrect table locks for resurrected transactions. */
 void trx_resurrect_locks();
 
-/** Release a trx_t instance back to the pool.
-@param[in,out]  trx the instance to release */
-void trx_free(trx_t *&trx);
+/** Free and initialize a transaction object instantiated during recovery.
+@param[in,out]	trx	transaction object to free and initialize */
+void trx_free_resurrected(trx_t *trx);
 
 /** Free a transaction that was allocated by background or user threads.
 @param[in,out]	trx	transaction object to free */
@@ -192,6 +192,10 @@ void trx_commit_low(
     trx_t *trx,  /*!< in/out: transaction */
     mtr_t *mtr); /*!< in/out: mini-transaction (will be committed),
                  or NULL if trx made no modifications */
+/** Cleans up a transaction at database startup. The cleanup is needed if
+ the transaction already got to the middle of a commit when the database
+ crashed, and we cannot roll it back. */
+void trx_cleanup_at_db_startup(trx_t *trx); /*!< in: transaction */
 /** Does the transaction commit for MySQL.
  @return DB_SUCCESS or error number */
 dberr_t trx_commit_for_mysql(trx_t *trx); /*!< in/out: transaction */

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2895,7 +2895,7 @@ void srv_dict_recover_on_restart() {
   The data dictionary latch should guarantee that there is at
   most one data dictionary transaction active at a time. */
   if (srv_force_recovery < SRV_FORCE_NO_TRX_UNDO) {
-    trx_rollback_recovered(false);
+    trx_rollback_or_clean_recovered(false);
   }
 
   /* Do after all DD transactions recovery, to get consistent metadata */


### PR DESCRIPTION
[Issue#28](https://github.com/kunpengcompute/mysql-server/issues/28) Revert function name to trx_rollback_recovered and restore function trx_cleanup_at_db_startup.