### PR TITLE
[Issue#34] FIX ASSERTION FAILURE: LOCK0LATCHES.CC:42

### DIFF
--- a/mysql-test/suite/innodb/r/lock_sys_resize.result
+++ b/mysql-test/suite/innodb/r/lock_sys_resize.result
@@ -1,0 +1,31 @@
+# Bug #31329634 ASSERTION FAILURE:
+#    LOCK0LATCHES.CC:42:LOCK_SYS->REC_HASH->N_CELLS == LOCK_SYS->P
+SELECT @@innodb_buffer_pool_size;
+@@innodb_buffer_pool_size
+17825792
+SELECT @@innodb_buffer_pool_chunk_size;
+@@innodb_buffer_pool_chunk_size
+1048576
+CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR(1000)) ENGINE=INNODB;
+INSERT INTO t1 (id,val) VALUES (1,''),(2,''),(3,''),(4,''),(5,'');
+SET DEBUG_SYNC='lock_rec_restore_from_page_infimum_will_latch
+    SIGNAL con1_will_latch
+    WAIT_FOR con1_can_go';
+UPDATE t1 SET val='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+SET DEBUG_SYNC='now WAIT_FOR con1_will_latch';
+SET GLOBAL DEBUG='+d,syncpoint_after_lock_sys_resize_rec_hash';
+SET GLOBAL innodb_buffer_pool_size=
+@@innodb_buffer_pool_size * 2 + @@innodb_buffer_pool_chunk_size;
+SET DEBUG_SYNC='now WAIT_FOR reached_after_lock_sys_resize_rec_hash';
+SET DEBUG_SYNC='now SIGNAL con1_can_go';
+SET GLOBAL DEBUG='-d,syncpoint_after_lock_sys_resize_rec_hash';
+SET DEBUG_SYNC='now SIGNAL continue_after_lock_sys_resize_rec_hash';
+DROP TABLE t1;
+SELECT @@innodb_buffer_pool_size;
+@@innodb_buffer_pool_size
+36700160
+SET GLOBAL innodb_buffer_pool_size=
+(@@innodb_buffer_pool_size - @@innodb_buffer_pool_chunk_size) div 2;
+SELECT @@innodb_buffer_pool_size;
+@@innodb_buffer_pool_size
+17825792

--- a/mysql-test/suite/innodb/t/lock_sys_resize-master.opt
+++ b/mysql-test/suite/innodb/t/lock_sys_resize-master.opt
@@ -1,0 +1,2 @@
+--innodb_buffer-pool-size=17825792
+--innodb-buffer-pool-chunk-size=1048576

--- a/mysql-test/suite/innodb/t/lock_sys_resize.test
+++ b/mysql-test/suite/innodb/t/lock_sys_resize.test
@@ -1,0 +1,76 @@
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+--echo # Bug #31329634 ASSERTION FAILURE:
+--echo #    LOCK0LATCHES.CC:42:LOCK_SYS->REC_HASH->N_CELLS == LOCK_SYS->P
+
+# The two values in master-opt were chosen so that the following
+# SET GLOBAL innodb_buffer_pool_size= ...
+# will succeed, and will resize lock_sys in parallel to the UPDATE.
+# (As opposed to say, block, as is the case when it shrinks instead of growing)
+# Also it must be larger than BUF_LRU_MIN_LEN pages, as otherwise BP shrink will
+# not be able to finish as it will try to keep BUF_LRU_MIN_LEN pages in BP.
+SELECT @@innodb_buffer_pool_size;
+SELECT @@innodb_buffer_pool_chunk_size;
+
+CREATE TABLE t1 (id INT PRIMARY KEY, val VARCHAR(1000)) ENGINE=INNODB;
+INSERT INTO t1 (id,val) VALUES (1,''),(2,''),(3,''),(4,''),(5,'');
+
+
+--connect (con1,localhost,root,,)
+  SET DEBUG_SYNC='lock_rec_restore_from_page_infimum_will_latch
+    SIGNAL con1_will_latch
+    WAIT_FOR con1_can_go';
+  # This will cause resize of records and require calls to
+  # lock_rec_restore_from_page_infimum() which exercise Shard_latches_guard
+  --send UPDATE t1 SET val='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+--connect (con2,localhost,root,,)
+  SET DEBUG_SYNC='now WAIT_FOR con1_will_latch';
+  # resize happens in a background thread so we need to enable sync point
+  SET GLOBAL DEBUG='+d,syncpoint_after_lock_sys_resize_rec_hash';
+  SET GLOBAL innodb_buffer_pool_size=
+    @@innodb_buffer_pool_size * 2 + @@innodb_buffer_pool_chunk_size;
+
+--connection default
+  SET DEBUG_SYNC='now WAIT_FOR reached_after_lock_sys_resize_rec_hash';
+  SET DEBUG_SYNC='now SIGNAL con1_can_go';
+  # This is the moment where con1 could observe assertion failure
+  SET GLOBAL DEBUG='-d,syncpoint_after_lock_sys_resize_rec_hash';
+  SET DEBUG_SYNC='now SIGNAL continue_after_lock_sys_resize_rec_hash';
+
+--connection con1
+  --reap
+
+
+--connection default
+--disconnect con1
+--disconnect con2
+
+DROP TABLE t1;
+
+# Make sure we finish previous resizing before issuing another
+let $wait_timeout = 60;
+let $wait_condition =
+  SELECT SUBSTR(variable_value, 1, 9) = 'Completed'
+  FROM performance_schema.global_status
+  WHERE variable_name = 'innodb_buffer_pool_resize_status';
+--source include/wait_condition.inc
+
+SELECT @@innodb_buffer_pool_size;
+
+# Restore original smaller size
+SET GLOBAL innodb_buffer_pool_size=
+  (@@innodb_buffer_pool_size - @@innodb_buffer_pool_chunk_size) div 2;
+# Make sure we finish resizing and restore original state before ending
+let $wait_timeout = 60;
+let $wait_condition =
+  SELECT SUBSTR(variable_value, 1, 9) = 'Completed'
+  FROM performance_schema.global_status
+  WHERE variable_name = 'innodb_buffer_pool_resize_status';
+--source include/wait_condition.inc
+
+SELECT @@innodb_buffer_pool_size;
+
+--source include/wait_until_count_sessions.inc

--- a/storage/innobase/include/lock0guards.h
+++ b/storage/innobase/include/lock0guards.h
@@ -119,23 +119,28 @@ class Shard_latch_guard {
 };
 
 /**
-A RAII wrapper class which s-latches the global lock_sys shard, and mutexes
-protecting specified shards for the duration of its scope.
+A RAII helper which latches the mutexes protecting specified shards for the
+duration of its scope.
 It makes sure to take the latches in correct order and handles the case where
 both pages are in the same shard correctly.
+You quite probably don't want to use this class, which only takes a shard's
+latch, without acquiring global_latch - which gives no protection from threads
+which latch only the global_latch exclusively to prevent any activity.
+You should use it in combination with Global_shared_latch_guard, so that you
+first obtain an s-latch on the global_latch, or simply use the
+Shard_latches_guard class which already combines the two for you.
 */
-class Shard_latches_guard {
-  explicit Shard_latches_guard(Lock_mutex &shard_mutex_a,
-                               Lock_mutex &shard_mutex_b);
+class Shard_naked_latches_guard {
+  explicit Shard_naked_latches_guard(Lock_mutex &shard_mutex_a,
+                                     Lock_mutex &shard_mutex_b);
 
  public:
-  explicit Shard_latches_guard(const buf_block_t &block_a,
-                               const buf_block_t &block_b);
+  explicit Shard_naked_latches_guard(const buf_block_t &block_a,
+                                     const buf_block_t &block_b);
 
-  ~Shard_latches_guard();
+  ~Shard_naked_latches_guard();
 
  private:
-  Global_shared_latch_guard m_global_shared_latch_guard;
   /** The "smallest" of the two shards' mutexes in the latching order */
   Lock_mutex &m_shard_mutex_1;
   /** The "largest" of the two shards' mutexes in the latching order */
@@ -143,6 +148,28 @@ class Shard_latches_guard {
   /** The ordering on shard mutexes used to avoid deadlocks */
   static constexpr std::less<Lock_mutex *> MUTEX_ORDER{};
 };
+/**
+A RAII wrapper class which s-latches the global lock_sys shard, and mutexes
+protecting specified shards for the duration of its scope.
+It makes sure to take the latches in correct order and handles the case where
+both pages are in the same shard correctly.
+The order of initialization is important: we have to take shared global latch
+BEFORE we attempt to use hash function to compute correct shard and latch it.
+*/
+class Shard_latches_guard {
+ public:
+  explicit Shard_latches_guard(const buf_block_t &block_a,
+                               const buf_block_t &block_b)
+      : m_global_shared_latch_guard{},
+        m_shard_naked_latches_guard{block_a, block_b} {}
+
+  ~Shard_latches_guard() {}
+
+ private:
+  Global_shared_latch_guard m_global_shared_latch_guard;
+  Shard_naked_latches_guard m_shard_naked_latches_guard;
+};
+
 }  // namespace locksys
 
 #endif /* lock0guards_h */

--- a/storage/innobase/include/lock0latches.h
+++ b/storage/innobase/include/lock0latches.h
@@ -244,8 +244,7 @@ class Latches {
   friend class Global_exclusive_try_latch;
   friend class Global_shared_latch_guard;
   friend class Shard_naked_latch_guard;
-  friend class Shard_latch_guard;
-  friend class Shard_latches_guard;
+  friend class Shard_naked_latches_guard;
 
   /** You should not use this functionality in new code.
   Instead use Global_exclusive_latch_guard.

--- a/storage/innobase/lock/lock0guards.cc
+++ b/storage/innobase/lock/lock0guards.cc
@@ -84,26 +84,26 @@ Global_shared_latch_guard::~Global_shared_latch_guard() {
   lock_sys->latches.global_latch.s_unlock();
 }
 
-/* Shard_latches_guard */
+/* Shard_naked_latches_guard */
 
-Shard_latches_guard::Shard_latches_guard(Lock_mutex &shard_mutex_a,
-                                         Lock_mutex &shard_mutex_b)
-    : m_global_shared_latch_guard{},
-      m_shard_mutex_1{*std::min(&shard_mutex_a, &shard_mutex_b, MUTEX_ORDER)},
+Shard_naked_latches_guard::Shard_naked_latches_guard(Lock_mutex &shard_mutex_a,
+                                                     Lock_mutex &shard_mutex_b)
+    : m_shard_mutex_1{*std::min(&shard_mutex_a, &shard_mutex_b, MUTEX_ORDER)},
       m_shard_mutex_2{*std::max(&shard_mutex_a, &shard_mutex_b, MUTEX_ORDER)} {
+  ut_ad(owns_shared_global_latch());
   if (&m_shard_mutex_1 != &m_shard_mutex_2) {
     mutex_enter(&m_shard_mutex_1);
   }
   mutex_enter(&m_shard_mutex_2);
 }
 
-Shard_latches_guard::Shard_latches_guard(const buf_block_t &block_a,
-                                         const buf_block_t &block_b)
-    : Shard_latches_guard{
+Shard_naked_latches_guard::Shard_naked_latches_guard(const buf_block_t &block_a,
+                                                     const buf_block_t &block_b)
+    : Shard_naked_latches_guard{
           lock_sys->latches.page_shards.get_mutex(block_a.get_page_id()),
           lock_sys->latches.page_shards.get_mutex(block_b.get_page_id())} {}
 
-Shard_latches_guard::~Shard_latches_guard() {
+Shard_naked_latches_guard::~Shard_naked_latches_guard() {
   mutex_exit(&m_shard_mutex_2);
   if (&m_shard_mutex_1 != &m_shard_mutex_2) {
     mutex_exit(&m_shard_mutex_1);

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -43,6 +43,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "btr0btr.h"
 #include "current_thd.h"
+#include "debug_sync.h" /* CONDITIONAL_SYNC_POINT */
 #include "dict0boot.h"
 #include "dict0mem.h"
 #include "ha_prototypes.h"
@@ -363,6 +364,18 @@ void lock_sys_resize(ulint n_cells) {
   lock_sys->rec_hash = hash_create(n_cells);
   HASH_MIGRATE(old_hash, lock_sys->rec_hash, lock_t, hash, lock_rec_lock_fold);
   hash_table_free(old_hash);
+
+  DBUG_EXECUTE_IF("syncpoint_after_lock_sys_resize_rec_hash", {
+    /* A workaround for buf_resize_thread() not using create_thd().
+    TBD: if buf_resize_thread() were to use create_thd() then should it be
+    instrumented (together or instead of os_thread_create instrumentation)? */
+    ut_ad(current_thd == nullptr);
+    THD *thd = create_thd(false, true, true, PSI_NOT_INSTRUMENTED);
+    ut_ad(current_thd == thd);
+    CONDITIONAL_SYNC_POINT("after_lock_sys_resize_rec_hash");
+    destroy_thd(thd);
+    ut_ad(current_thd == nullptr);
+  });
 
   old_hash = lock_sys->prdt_hash;
   lock_sys->prdt_hash = hash_create(n_cells);
@@ -2648,7 +2661,7 @@ void lock_move_reorganize_page(
 
       ut_ad(lock_rec_find_set_bit(lock) == ULINT_UNDEFINED);
     }
-  } /* Shard_latches_guard */
+  } /* Shard_latch_guard */
 
   mem_heap_free(heap);
 
@@ -3242,6 +3255,7 @@ void lock_rec_restore_from_page_infimum(
                                 state; lock bits are reset on
                                 the infimum */
 {
+  DEBUG_SYNC_C("lock_rec_restore_from_page_infimum_will_latch");
   ulint heap_no = page_rec_get_heap_no(rec);
 
   locksys::Shard_latches_guard guard{*block, *donator};


### PR DESCRIPTION
[Issue#34](https://github.com/kunpengcompute/mysql-server/issues/34) The fix is to use similar approach for `Shard_latches_guard` as was already used in `Shard_latch_guard`, which was to separate two aspects:
1. obtaining the global s-latch
2. obtaining shard-level latches
The second task was handled by a low-level `Shard_naked_latch_guard`, and the `Shard_latch_guard` made sure to combine `Shard_naked_latch_guard` with `Global_shared_latch_guard` in correct order.
Thus, this fix introduces an anologous `Shard_naked_latches_guard` class and moves the responsibility for shard-level latches to it, while the `Shard_latches_guard` will only care about combining this with `Global_shared_latch_guard` correctly.