### PR TITLE
[Issue#24] codecheck整改

### DIFF
--- a/storage/innobase/include/lock0guards.h
+++ b/storage/innobase/include/lock0guards.h
@@ -160,8 +160,8 @@ class Shard_latches_guard {
  public:
   explicit Shard_latches_guard(const buf_block_t &block_a,
                                const buf_block_t &block_b)
-      : m_global_shared_latch_guard{},
-        m_shard_naked_latches_guard{block_a, block_b} {}
+    : m_global_shared_latch_guard{},
+      m_shard_naked_latches_guard{block_a, block_b} {}
 
   ~Shard_latches_guard() {}
 
@@ -169,7 +169,6 @@ class Shard_latches_guard {
   Global_shared_latch_guard m_global_shared_latch_guard;
   Shard_naked_latches_guard m_shard_naked_latches_guard;
 };
-
 }  // namespace locksys
 
 #endif /* lock0guards_h */

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -366,9 +366,7 @@ void lock_sys_resize(ulint n_cells) {
   hash_table_free(old_hash);
 
   DBUG_EXECUTE_IF("syncpoint_after_lock_sys_resize_rec_hash", {
-    /* A workaround for buf_resize_thread() not using create_thd().
-    TBD: if buf_resize_thread() were to use create_thd() then should it be
-    instrumented (together or instead of os_thread_create instrumentation)? */
+    /* A workaround for buf_resize_thread() not using create_thd(). */
     ut_ad(current_thd == nullptr);
     THD *thd = create_thd(false, true, true, PSI_NOT_INSTRUMENTED);
     ut_ad(current_thd == thd);


### PR DESCRIPTION
codecheck整改，满足以下规则
1.构造函数初始化列表按四空格缩进并排多行
2.合理安排空行
3.注释不能包含TBD

修复： [Issue #24](https://github.com/kunpengcompute/mysql-server/issues/24)