### PR TITLE
[Issue#52]Support finer-grain control on MySQL threads

### DIFF
--- a/mysql-test/include/query_sched_affinity_sys_var.inc
+++ b/mysql-test/include/query_sched_affinity_sys_var.inc
@@ -6,3 +6,4 @@ SHOW VARIABLES LIKE 'sched_affinity_log_flush_notifier';
 SHOW VARIABLES LIKE 'sched_affinity_log_closer';
 SHOW VARIABLES LIKE 'sched_affinity_log_checkpointer';
 SHOW VARIABLES LIKE 'sched_affinity_purge_coordinator';
+SHOW VARIABLES LIKE 'sched_affinity_numa_aware';

--- a/mysql-test/include/sched_affinity_manager.inc
+++ b/mysql-test/include/sched_affinity_manager.inc
@@ -34,12 +34,45 @@ if ($sched_affinity_group_capacity < $target_sched_affinity_group_capacity) {
 --source include/restart_mysqld.inc
 --source include/query_sched_affinity_sys_var.inc
 
+--echo # set foreground sys_var, log_writer sys_var and numa_aware sys_var
+--let $restart_parameters="restart: --sched_affinity_foreground_thread=0-3,5,6 --sched_affinity_log_writer=4 --sched_affinity_numa_aware=ON"
+--source include/restart_mysqld.inc
+--source include/query_sched_affinity_sys_var.inc
+
 --echo # test foreground thread group
 --let $group1=0,1,2
 --let $range=1
 --let $group2_from=$sched_affinity_group_capacity
 --expr $group2_to=$sched_affinity_group_capacity + $range
 --let $restart_parameters="restart: --sched_affinity_foreground_thread=$group1,$group2_from-$group2_to"
+--source include/restart_mysqld.inc
+--source include/query_sched_affinity_sys_var.inc
+
+--let $i=0
+--let $connection_number = 100
+while ($i<$connection_number)
+{
+  --connect(conn$i,localhost,root,,)
+  --connection default
+  SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+  --inc $i
+}
+
+--let $i=0
+while ($i<$connection_number)
+{
+  --disconnect conn$i
+  --connection default
+  SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+  --inc $i
+}
+
+--echo # test foreground thread group with numa_aware
+--let $group1=0,1,2
+--let $range=1
+--let $group2_from=$sched_affinity_group_capacity
+--expr $group2_to=$sched_affinity_group_capacity + $range
+--let $restart_parameters="restart: --sched_affinity_foreground_thread=$group1,$group2_from-$group2_to --sched_affinity_numa_aware=ON"
 --source include/restart_mysqld.inc
 --source include/query_sched_affinity_sys_var.inc
 

--- a/mysql-test/r/sched_affinity_manager.result
+++ b/mysql-test/r/sched_affinity_manager.result
@@ -23,6 +23,9 @@ sched_affinity_log_checkpointer
 SHOW VARIABLES LIKE 'sched_affinity_purge_coordinator';
 Variable_name	Value
 sched_affinity_purge_coordinator	
+SHOW VARIABLES LIKE 'sched_affinity_numa_aware';
+Variable_name	Value
+sched_affinity_numa_aware	OFF
 # set foreground sys_var
 # restart: --sched_affinity_foreground_thread=0-3,5,6
 SHOW VARIABLES LIKE 'sched_affinity_foreground_thread';
@@ -49,6 +52,9 @@ sched_affinity_log_checkpointer
 SHOW VARIABLES LIKE 'sched_affinity_purge_coordinator';
 Variable_name	Value
 sched_affinity_purge_coordinator	
+SHOW VARIABLES LIKE 'sched_affinity_numa_aware';
+Variable_name	Value
+sched_affinity_numa_aware	OFF
 # set log_writer sys_var
 # restart: --sched_affinity_log_writer=4
 SHOW VARIABLES LIKE 'sched_affinity_foreground_thread';
@@ -75,6 +81,9 @@ sched_affinity_log_checkpointer
 SHOW VARIABLES LIKE 'sched_affinity_purge_coordinator';
 Variable_name	Value
 sched_affinity_purge_coordinator	
+SHOW VARIABLES LIKE 'sched_affinity_numa_aware';
+Variable_name	Value
+sched_affinity_numa_aware	OFF
 # set foreground sys_var and log_writer sys_var
 # restart: --sched_affinity_foreground_thread=0-3,5,6 --sched_affinity_log_writer=4
 SHOW VARIABLES LIKE 'sched_affinity_foreground_thread';
@@ -101,6 +110,38 @@ sched_affinity_log_checkpointer
 SHOW VARIABLES LIKE 'sched_affinity_purge_coordinator';
 Variable_name	Value
 sched_affinity_purge_coordinator	
+SHOW VARIABLES LIKE 'sched_affinity_numa_aware';
+Variable_name	Value
+sched_affinity_numa_aware	OFF
+# set foreground sys_var, log_writer sys_var and numa_aware sys_var
+# restart: --sched_affinity_foreground_thread=0-3,5,6 --sched_affinity_log_writer=4 --sched_affinity_numa_aware=ON
+SHOW VARIABLES LIKE 'sched_affinity_foreground_thread';
+Variable_name	Value
+sched_affinity_foreground_thread	0-3,5,6
+SHOW VARIABLES LIKE 'sched_affinity_log_writer';
+Variable_name	Value
+sched_affinity_log_writer	4
+SHOW VARIABLES LIKE 'sched_affinity_log_flusher';
+Variable_name	Value
+sched_affinity_log_flusher	
+SHOW VARIABLES LIKE 'sched_affinity_log_write_notifier';
+Variable_name	Value
+sched_affinity_log_write_notifier	
+SHOW VARIABLES LIKE 'sched_affinity_log_flush_notifier';
+Variable_name	Value
+sched_affinity_log_flush_notifier	
+SHOW VARIABLES LIKE 'sched_affinity_log_closer';
+Variable_name	Value
+sched_affinity_log_closer	
+SHOW VARIABLES LIKE 'sched_affinity_log_checkpointer';
+Variable_name	Value
+sched_affinity_log_checkpointer	
+SHOW VARIABLES LIKE 'sched_affinity_purge_coordinator';
+Variable_name	Value
+sched_affinity_purge_coordinator	
+SHOW VARIABLES LIKE 'sched_affinity_numa_aware';
+Variable_name	Value
+sched_affinity_numa_aware	ON
 # test foreground thread group
 # restart: --sched_affinity_foreground_thread=0,1,2,24-25
 SHOW VARIABLES LIKE 'sched_affinity_foreground_thread';
@@ -127,603 +168,1235 @@ sched_affinity_log_checkpointer
 SHOW VARIABLES LIKE 'sched_affinity_purge_coordinator';
 Variable_name	Value
 sched_affinity_purge_coordinator	
+SHOW VARIABLES LIKE 'sched_affinity_numa_aware';
+Variable_name	Value
+sched_affinity_numa_aware	OFF
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-1/3; 1/2
+foreground: 2/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-2/3; 1/2
+foreground: 3/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-2/3; 2/2
+foreground: 4/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-3/3; 2/2
+foreground: 5/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-4/3; 2/2
+foreground: 6/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-4/3; 3/2
+foreground: 7/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-5/3; 3/2
+foreground: 8/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-5/3; 4/2
+foreground: 9/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-6/3; 4/2
+foreground: 10/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-7/3; 4/2
+foreground: 11/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-7/3; 5/2
+foreground: 12/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-8/3; 5/2
+foreground: 13/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-8/3; 6/2
+foreground: 14/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-9/3; 6/2
+foreground: 15/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-10/3; 6/2
+foreground: 16/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-10/3; 7/2
+foreground: 17/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-11/3; 7/2
+foreground: 18/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-11/3; 8/2
+foreground: 19/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-12/3; 8/2
+foreground: 20/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-13/3; 8/2
+foreground: 21/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-13/3; 9/2
+foreground: 22/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-14/3; 9/2
+foreground: 23/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-14/3; 10/2
+foreground: 24/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-15/3; 10/2
+foreground: 25/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-16/3; 10/2
+foreground: 26/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-16/3; 11/2
+foreground: 27/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-17/3; 11/2
+foreground: 28/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-17/3; 12/2
+foreground: 29/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-18/3; 12/2
+foreground: 30/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-19/3; 12/2
+foreground: 31/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-19/3; 13/2
+foreground: 32/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-20/3; 13/2
+foreground: 33/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-20/3; 14/2
+foreground: 34/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-21/3; 14/2
+foreground: 35/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-22/3; 14/2
+foreground: 36/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-22/3; 15/2
+foreground: 37/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-23/3; 15/2
+foreground: 38/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-23/3; 16/2
+foreground: 39/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-24/3; 16/2
+foreground: 40/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-25/3; 16/2
+foreground: 41/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-25/3; 17/2
+foreground: 42/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-26/3; 17/2
+foreground: 43/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-26/3; 18/2
+foreground: 44/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-27/3; 18/2
+foreground: 45/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-28/3; 18/2
+foreground: 46/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-28/3; 19/2
+foreground: 47/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-29/3; 19/2
+foreground: 48/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-29/3; 20/2
+foreground: 49/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-30/3; 20/2
+foreground: 50/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-31/3; 20/2
+foreground: 51/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-31/3; 21/2
+foreground: 52/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-32/3; 21/2
+foreground: 53/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-32/3; 22/2
+foreground: 54/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-33/3; 22/2
+foreground: 55/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-34/3; 22/2
+foreground: 56/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-34/3; 23/2
+foreground: 57/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-35/3; 23/2
+foreground: 58/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-35/3; 24/2
+foreground: 59/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-36/3; 24/2
+foreground: 60/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-37/3; 24/2
+foreground: 61/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-37/3; 25/2
+foreground: 62/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-38/3; 25/2
+foreground: 63/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-38/3; 26/2
+foreground: 64/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-39/3; 26/2
+foreground: 65/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-40/3; 26/2
+foreground: 66/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-40/3; 27/2
+foreground: 67/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-41/3; 27/2
+foreground: 68/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-41/3; 28/2
+foreground: 69/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-42/3; 28/2
+foreground: 70/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-43/3; 28/2
+foreground: 71/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-43/3; 29/2
+foreground: 72/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-44/3; 29/2
+foreground: 73/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-44/3; 30/2
+foreground: 74/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-45/3; 30/2
+foreground: 75/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-46/3; 30/2
+foreground: 76/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-46/3; 31/2
+foreground: 77/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-47/3; 31/2
+foreground: 78/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-47/3; 32/2
+foreground: 79/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-48/3; 32/2
+foreground: 80/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-49/3; 32/2
+foreground: 81/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-49/3; 33/2
+foreground: 82/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-50/3; 33/2
+foreground: 83/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-50/3; 34/2
+foreground: 84/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-51/3; 34/2
+foreground: 85/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-52/3; 34/2
+foreground: 86/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-52/3; 35/2
+foreground: 87/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-53/3; 35/2
+foreground: 88/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-53/3; 36/2
+foreground: 89/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-54/3; 36/2
+foreground: 90/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-55/3; 36/2
+foreground: 91/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-55/3; 37/2
+foreground: 92/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-56/3; 37/2
+foreground: 93/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-56/3; 38/2
+foreground: 94/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-57/3; 38/2
+foreground: 95/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-58/3; 38/2
+foreground: 96/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-58/3; 39/2
+foreground: 97/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-59/3; 39/2
+foreground: 98/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-59/3; 40/2
+foreground: 99/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-60/3; 40/2
+foreground: 100/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-61/3; 40/2
+foreground: 101/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-61/3; 39/2
+foreground: 100/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-60/3; 39/2
+foreground: 99/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-60/3; 38/2
+foreground: 98/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-59/3; 38/2
+foreground: 97/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-58/3; 38/2
+foreground: 96/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-58/3; 37/2
+foreground: 95/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-57/3; 37/2
+foreground: 94/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-57/3; 36/2
+foreground: 93/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-56/3; 36/2
+foreground: 92/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-55/3; 36/2
+foreground: 91/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-55/3; 35/2
+foreground: 90/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-54/3; 35/2
+foreground: 89/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-54/3; 34/2
+foreground: 88/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-53/3; 34/2
+foreground: 87/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-52/3; 34/2
+foreground: 86/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-52/3; 33/2
+foreground: 85/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-51/3; 33/2
+foreground: 84/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-51/3; 32/2
+foreground: 83/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-50/3; 32/2
+foreground: 82/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-49/3; 32/2
+foreground: 81/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-49/3; 31/2
+foreground: 80/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-48/3; 31/2
+foreground: 79/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-48/3; 30/2
+foreground: 78/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-47/3; 30/2
+foreground: 77/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-46/3; 30/2
+foreground: 76/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-46/3; 29/2
+foreground: 75/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-45/3; 29/2
+foreground: 74/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-45/3; 28/2
+foreground: 73/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-44/3; 28/2
+foreground: 72/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-43/3; 28/2
+foreground: 71/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-43/3; 27/2
+foreground: 70/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-42/3; 27/2
+foreground: 69/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-42/3; 26/2
+foreground: 68/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-41/3; 26/2
+foreground: 67/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-40/3; 26/2
+foreground: 66/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-40/3; 25/2
+foreground: 65/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-39/3; 25/2
+foreground: 64/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-39/3; 24/2
+foreground: 63/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-38/3; 24/2
+foreground: 62/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-37/3; 24/2
+foreground: 61/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-37/3; 23/2
+foreground: 60/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-36/3; 23/2
+foreground: 59/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-36/3; 22/2
+foreground: 58/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-35/3; 22/2
+foreground: 57/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-34/3; 22/2
+foreground: 56/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-34/3; 21/2
+foreground: 55/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-33/3; 21/2
+foreground: 54/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-33/3; 20/2
+foreground: 53/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-32/3; 20/2
+foreground: 52/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-31/3; 20/2
+foreground: 51/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-31/3; 19/2
+foreground: 50/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-30/3; 19/2
+foreground: 49/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-30/3; 18/2
+foreground: 48/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-29/3; 18/2
+foreground: 47/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-28/3; 18/2
+foreground: 46/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-28/3; 17/2
+foreground: 45/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-27/3; 17/2
+foreground: 44/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-27/3; 16/2
+foreground: 43/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-26/3; 16/2
+foreground: 42/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-25/3; 16/2
+foreground: 41/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-25/3; 15/2
+foreground: 40/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-24/3; 15/2
+foreground: 39/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-24/3; 14/2
+foreground: 38/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-23/3; 14/2
+foreground: 37/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-22/3; 14/2
+foreground: 36/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-22/3; 13/2
+foreground: 35/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-21/3; 13/2
+foreground: 34/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-21/3; 12/2
+foreground: 33/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-20/3; 12/2
+foreground: 32/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-19/3; 12/2
+foreground: 31/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-19/3; 11/2
+foreground: 30/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-18/3; 11/2
+foreground: 29/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-18/3; 10/2
+foreground: 28/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-17/3; 10/2
+foreground: 27/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-16/3; 10/2
+foreground: 26/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-16/3; 9/2
+foreground: 25/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-15/3; 9/2
+foreground: 24/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-15/3; 8/2
+foreground: 23/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-14/3; 8/2
+foreground: 22/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-13/3; 8/2
+foreground: 21/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-13/3; 7/2
+foreground: 20/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-12/3; 7/2
+foreground: 19/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-12/3; 6/2
+foreground: 18/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-11/3; 6/2
+foreground: 17/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-10/3; 6/2
+foreground: 16/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-10/3; 5/2
+foreground: 15/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-9/3; 5/2
+foreground: 14/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-9/3; 4/2
+foreground: 13/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-8/3; 4/2
+foreground: 12/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-7/3; 4/2
+foreground: 11/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-7/3; 3/2
+foreground: 10/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-6/3; 3/2
+foreground: 9/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-6/3; 2/2
+foreground: 8/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-5/3; 2/2
+foreground: 7/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-4/3; 2/2
+foreground: 6/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-4/3; 1/2
+foreground: 5/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-3/3; 1/2
+foreground: 4/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-3/3; 0/2
+foreground: 3/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-2/3; 0/2
+foreground: 2/5; 
 SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
 SUBSTRING_INDEX(variable_value,';',2)
-1/3; 0/2
+foreground: 1/5; 
+# test foreground thread group with numa_aware
+# restart: --sched_affinity_foreground_thread=0,1,2,24-25 --sched_affinity_numa_aware=ON
+SHOW VARIABLES LIKE 'sched_affinity_foreground_thread';
+Variable_name	Value
+sched_affinity_foreground_thread	0,1,2,24-25
+SHOW VARIABLES LIKE 'sched_affinity_log_writer';
+Variable_name	Value
+sched_affinity_log_writer	
+SHOW VARIABLES LIKE 'sched_affinity_log_flusher';
+Variable_name	Value
+sched_affinity_log_flusher	
+SHOW VARIABLES LIKE 'sched_affinity_log_write_notifier';
+Variable_name	Value
+sched_affinity_log_write_notifier	
+SHOW VARIABLES LIKE 'sched_affinity_log_flush_notifier';
+Variable_name	Value
+sched_affinity_log_flush_notifier	
+SHOW VARIABLES LIKE 'sched_affinity_log_closer';
+Variable_name	Value
+sched_affinity_log_closer	
+SHOW VARIABLES LIKE 'sched_affinity_log_checkpointer';
+Variable_name	Value
+sched_affinity_log_checkpointer	
+SHOW VARIABLES LIKE 'sched_affinity_purge_coordinator';
+Variable_name	Value
+sched_affinity_purge_coordinator	
+SHOW VARIABLES LIKE 'sched_affinity_numa_aware';
+Variable_name	Value
+sched_affinity_numa_aware	ON
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 1/3; 1/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 2/3; 1/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 2/3; 2/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 3/3; 2/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 4/3; 2/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 4/3; 3/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 5/3; 3/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 5/3; 4/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 6/3; 4/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 7/3; 4/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 7/3; 5/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 8/3; 5/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 8/3; 6/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 9/3; 6/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 10/3; 6/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 10/3; 7/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 11/3; 7/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 11/3; 8/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 12/3; 8/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 13/3; 8/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 13/3; 9/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 14/3; 9/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 14/3; 10/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 15/3; 10/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 16/3; 10/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 16/3; 11/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 17/3; 11/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 17/3; 12/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 18/3; 12/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 19/3; 12/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 19/3; 13/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 20/3; 13/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 20/3; 14/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 21/3; 14/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 22/3; 14/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 22/3; 15/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 23/3; 15/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 23/3; 16/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 24/3; 16/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 25/3; 16/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 25/3; 17/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 26/3; 17/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 26/3; 18/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 27/3; 18/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 28/3; 18/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 28/3; 19/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 29/3; 19/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 29/3; 20/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 30/3; 20/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 31/3; 20/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 31/3; 21/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 32/3; 21/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 32/3; 22/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 33/3; 22/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 34/3; 22/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 34/3; 23/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 35/3; 23/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 35/3; 24/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 36/3; 24/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 37/3; 24/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 37/3; 25/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 38/3; 25/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 38/3; 26/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 39/3; 26/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 40/3; 26/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 40/3; 27/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 41/3; 27/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 41/3; 28/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 42/3; 28/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 43/3; 28/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 43/3; 29/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 44/3; 29/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 44/3; 30/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 45/3; 30/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 46/3; 30/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 46/3; 31/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 47/3; 31/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 47/3; 32/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 48/3; 32/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 49/3; 32/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 49/3; 33/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 50/3; 33/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 50/3; 34/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 51/3; 34/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 52/3; 34/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 52/3; 35/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 53/3; 35/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 53/3; 36/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 54/3; 36/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 55/3; 36/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 55/3; 37/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 56/3; 37/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 56/3; 38/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 57/3; 38/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 58/3; 38/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 58/3; 39/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 59/3; 39/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 59/3; 40/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 60/3; 40/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 61/3; 40/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 61/3; 39/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 60/3; 39/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 60/3; 38/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 59/3; 38/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 58/3; 38/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 58/3; 37/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 57/3; 37/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 57/3; 36/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 56/3; 36/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 55/3; 36/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 55/3; 35/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 54/3; 35/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 54/3; 34/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 53/3; 34/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 52/3; 34/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 52/3; 33/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 51/3; 33/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 51/3; 32/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 50/3; 32/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 49/3; 32/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 49/3; 31/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 48/3; 31/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 48/3; 30/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 47/3; 30/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 46/3; 30/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 46/3; 29/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 45/3; 29/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 45/3; 28/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 44/3; 28/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 43/3; 28/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 43/3; 27/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 42/3; 27/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 42/3; 26/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 41/3; 26/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 40/3; 26/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 40/3; 25/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 39/3; 25/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 39/3; 24/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 38/3; 24/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 37/3; 24/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 37/3; 23/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 36/3; 23/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 36/3; 22/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 35/3; 22/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 34/3; 22/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 34/3; 21/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 33/3; 21/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 33/3; 20/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 32/3; 20/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 31/3; 20/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 31/3; 19/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 30/3; 19/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 30/3; 18/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 29/3; 18/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 28/3; 18/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 28/3; 17/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 27/3; 17/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 27/3; 16/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 26/3; 16/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 25/3; 16/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 25/3; 15/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 24/3; 15/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 24/3; 14/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 23/3; 14/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 22/3; 14/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 22/3; 13/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 21/3; 13/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 21/3; 12/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 20/3; 12/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 19/3; 12/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 19/3; 11/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 18/3; 11/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 18/3; 10/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 17/3; 10/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 16/3; 10/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 16/3; 9/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 15/3; 9/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 15/3; 8/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 14/3; 8/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 13/3; 8/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 13/3; 7/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 12/3; 7/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 12/3; 6/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 11/3; 6/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 10/3; 6/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 10/3; 5/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 9/3; 5/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 9/3; 4/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 8/3; 4/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 7/3; 4/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 7/3; 3/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 6/3; 3/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 6/3; 2/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 5/3; 2/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 4/3; 2/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 4/3; 1/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 3/3; 1/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 3/3; 0/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 2/3; 0/2
+SELECT SUBSTRING_INDEX(variable_value,';',2) from performance_schema.global_status WHERE variable_name='Sched_affinity_status';
+SUBSTRING_INDEX(variable_value,';',2)
+foreground: 1/3; 0/2

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8209,8 +8209,9 @@ static int show_queries(THD *thd, SHOW_VAR *var, char *) {
 static int show_sched_affinity_status(THD *, SHOW_VAR *var, char *buff) {
   var->type = SHOW_CHAR;
   var->value = buff;
-  sched_affinity::Sched_affinity_manager::get_instance()->take_snapshot(
-      buff, SHOW_VAR_FUNC_BUFF_SIZE + 1);
+  std::string group_snapshot = sched_affinity::Sched_affinity_manager::get_instance()->take_group_snapshot();
+  strncpy(buff, group_snapshot.c_str(), SHOW_VAR_FUNC_BUFF_SIZE);
+  buff[SHOW_VAR_FUNC_BUFF_SIZE]='\0';
   return 0;
 }
 

--- a/sql/sched_affinity_manager.h
+++ b/sql/sched_affinity_manager.h
@@ -53,7 +53,7 @@ class Sched_affinity_manager {
   virtual bool unregister_thread(const Thread_type thread_type,
                                  const pid_t pid) = 0;
   virtual bool rebalance_group(const Thread_type thread_type) = 0;
-  virtual void take_snapshot(char *buff, int buff_size) = 0;
+  virtual std::string take_group_snapshot() = 0;
   virtual int get_total_node_number() = 0;
   virtual int get_cpu_number_per_node() = 0;
   virtual bool check_cpu_string(const std::string &cpu_string) = 0;
@@ -77,7 +77,7 @@ class Sched_affinity_manager_dummy : public Sched_affinity_manager {
     return true;
   }
   bool rebalance_group(const Thread_type) { return true; }
-  void take_snapshot(char *buff, int buff_size) override;
+  std::string take_group_snapshot() override;
   int get_total_node_number() override { return -1; }
   int get_cpu_number_per_node() override { return -1; }
   bool check_cpu_string(const std::string &) override { return true; }
@@ -112,7 +112,7 @@ class Sched_affinity_manager_numa : public Sched_affinity_manager {
   bool unregister_thread(const Thread_type thread_type,
                          const pid_t pid) override;
   bool rebalance_group(const Thread_type thread_type) override;
-  void take_snapshot(char *buff, int buff_size) override;
+  std::string take_group_snapshot() override;
   int get_total_node_number() override;
   int get_cpu_number_per_node() override;
   bool check_cpu_string(const std::string &cpu_string) override;


### PR DESCRIPTION
[Issue52](https://github.com/kunpengcompute/mysql-server/issues/52) 
1. Fix a bug which causes unbind_from_group failure.
2. Modify mtr case sched_affinity_manager to test numa_aware=OFF scenario.
3. System status Sched_affinity now shows all enabled thread type groups.