### PR TITLE
并行查询特性mtr失败用例query_rewrite_plugins.joins修改

### DIFF
--- a/sql/item.h
+++ b/sql/item.h
@@ -3408,6 +3408,7 @@ class Item_ident : public Item {
           cached_table should be replaced by table_ref ASAP.
   */
   TABLE_LIST *cached_table;
+  uint m_tableno{0};
   SELECT_LEX *depended_from;
 
   Item_ident(Name_resolution_context *context_arg, const char *db_name_arg,
@@ -3692,6 +3693,7 @@ class Item_field : public Item_ident {
   bool itemize(Parse_context *pc, Item **res) override;
 
   Item *pq_clone(THD *thd, SELECT_LEX *select) override;
+  bool pq_copy_from(THD *thd, SELECT_LEX *select, Item *item) override;
   enum Type type() const override { return FIELD_ITEM; }
   bool eq(const Item *item, bool binary_cmp) const override;
   double val_real() override;

--- a/sql/pq_clone_item.cc
+++ b/sql/pq_clone_item.cc
@@ -304,6 +304,21 @@ PQ_COPY_FROM_DEF(Item_ident, Item) {
     DBUG_EXECUTE_IF("simulate_item_clone_attr_copy_error", return true;);
 
     context = &select->context;
+
+    if (orig_item->cached_table == nullptr) {
+      m_tableno = orig_item->m_tableno;
+    } else {
+      m_tableno = orig_item->cached_table->m_tableno;
+    }
+  }
+PQ_COPY_FROM_RETURN
+
+PQ_COPY_FROM_DEF(Item_field, Item_ident) {
+    DBUG_EXECUTE_IF("simulate_item_field_copy_error", return true;);
+
+    if (orig_item->table_ref != nullptr) {
+      m_tableno = orig_item->table_ref->m_tableno;
+    }
   }
 PQ_COPY_FROM_RETURN
 

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -7740,10 +7740,16 @@ Field *find_field_in_tables(THD *thd, Item_ident *item, TABLE_LIST *first_table,
   auto cur_table = first_table;
   for (; cur_table != last_table && cur_table != last_table2;
        cur_table = cur_table->next_name_resolution_table) {
-    Field *cur_field = find_field_in_table_ref(
+    Field *cur_field = nullptr;
+    if (thd->parallel_exec && item->m_tableno != cur_table->m_tableno) {
+      continue;
+    } else {
+      cur_field = find_field_in_table_ref(
         thd, cur_table, name, length, item->item_name.ptr(), db, table_name,
         ref, want_privilege, allow_rowid, &(item->cached_field_index),
         register_tree_change, &actual_table);
+    }
+    
     if ((cur_field == nullptr && thd->is_error()) || cur_field == WRONG_GRANT)
       return nullptr;
 

--- a/sql/table.h
+++ b/sql/table.h
@@ -3162,13 +3162,14 @@ struct TABLE_LIST {
 
   const Lock_descriptor &lock_descriptor() const { return m_lock_descriptor; }
 
- private:
+ public:
   /**
     The members below must be kept aligned so that (1 << m_tableno) == m_map.
     A table that takes part in a join operation must be assigned a unique
     table number.
   */
   uint m_tableno{0};   ///< Table number within query block
+ private:
   table_map m_map{0};  ///< Table map, derived from m_tableno
   /**
      If this table or join nest is the Y in "X [LEFT] JOIN Y ON C", this


### PR DESCRIPTION
修复query_rewrite_plugins.joins，perfschema.start_server_no_digests，perfschema.digest_table_full等用例；
问题现象：查询结果错误；
问题原因：item找表错误。