### PR TITLE
Repair the MTR main.group_by_fd_no_prot

### DIFF
--- a/sql/pq_clone.h
+++ b/sql/pq_clone.h
@@ -31,9 +31,18 @@ class SELECT_LEX;
 class JOIN;
 class ORDER;
 class ORDER_with_src;
+class TABLE_LIST;
+enum table_list_type_enum {
+  TABLE_LIST_TYPE_DEFAULT,
+  TABLE_LIST_TYPE_LEAF,
+  TABLE_LIST_TYPE_GLOBAL,
+  TABLE_LIST_TYPE_MERGE
+};
 
 bool pq_dup_tabs(JOIN *pq_join, JOIN *join, bool setup);
 
+TABLE_LIST *get_table_by_index(TABLE_LIST* start_table, table_list_type_enum list_type, int index);
+int get_table_index(TABLE_LIST* start_table, table_list_type_enum list_type, TABLE_LIST *tl);
 extern Item **resolve_ref_in_select_and_group(THD *thd, Item_ident *ref,
                                               SELECT_LEX *select);
 

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -1002,6 +1002,7 @@ enum class enum_explain_type {
 */
 class SELECT_LEX {
  public:
+  SELECT_LEX *orig;
   Item *where_cond() const { return m_where_cond; }
   Item **where_cond_ref() { return &m_where_cond; }
   void set_where_cond(Item *cond) { m_where_cond = cond; }

--- a/sql/table.h
+++ b/sql/table.h
@@ -3351,10 +3351,9 @@ struct TABLE_LIST {
   ulonglong algorithm{0};
   ulonglong view_suid{0};   ///< view is suid (true by default)
   ulonglong with_check{0};  ///< WITH CHECK OPTION
-
+  enum_view_algorithm effective_algorithm{VIEW_ALGORITHM_UNDEFINED};
  private:
   /// The view algorithm that is actually used, if this is a view.
-  enum_view_algorithm effective_algorithm{VIEW_ALGORITHM_UNDEFINED};
   Lock_descriptor m_lock_descriptor;
 
  public:


### PR DESCRIPTION
1:   修改table_list和leaf_tables的复制方法，分别从原生的table_list和leaf_tables复制。使数据和原生保持一致。
2：增加拷贝TABLE_LIST对象的field_translation数组，Item_view_ref对象的ref指针指向数组里面的元素。
3：修改Item_view_ref对象的拷贝方法，使拷贝出来的对象仍然为Item_view_ref对象。更加容易借用原生代码。
4：增加TABLE_LIST的outer_join，这个属性在Item_view_ref对象的has_null_row方法里面用到，该方法判断结果是否为空。对应的sql语句为 select d.a,d.c from t1 left join (select a, coalesce(a,3) as c from t1) as d on t1.b>0;

