### PR TITLE
[Issue#76]Fix intermittent shutdown crashes if threadpool is enabled.

### DIFF
--- a/mysql-test/suite/thread_pool/r/threadpool_shutdown.result
+++ b/mysql-test/suite/thread_pool/r/threadpool_shutdown.result
@@ -1,0 +1,35 @@
+CREATE DATABASE db1;
+CREATE TABLE db1.t1 (
+c1 int NOT NULL,
+c2 int NOT NULL,
+PRIMARY KEY (c1)
+);
+INSERT INTO db1.t1 (c1,c2) VALUES (1,11);
+INSERT INTO db1.t1 (c1,c2) VALUES (2,22);
+INSERT INTO db1.t1 (c1,c2) VALUES (3,33);
+START TRANSACTION;
+SELECT * FROM db1.t1 WHERE c1=2 FOR UPDATE;
+c1	c2
+2	22
+START TRANSACTION;
+SELECT * FROM db1.t1 WHERE c1=2 LOCK IN SHARE MODE;
+# Shutdown the server
+# Start the server
+# restart
+SELECT benchmark(9999999999, md5('very long command 1'));
+SELECT benchmark(9999999999, md5('very long command 2'));
+# Shutdown the server
+# Start the server
+# restart
+SELECT * FROM db1.t1 WHERE c1=1;
+c1	c2
+1	11
+SELECT * FROM db1.t1 WHERE c1=2;
+c1	c2
+2	22
+# Shutdown the server
+# Start the server
+# restart
+# Cleanup
+DROP TABLE db1.t1;
+DROP DATABASE db1;

--- a/mysql-test/suite/thread_pool/t/threadpool_shutdown.cnf
+++ b/mysql-test/suite/thread_pool/t/threadpool_shutdown.cnf
@@ -1,0 +1,6 @@
+!include include/default_my.cnf
+
+[mysqld.1]
+loose-thread-handling=pool-of-threads
+loose-thread_pool_size=1
+loose-thread_pool_oversubscribe=3

--- a/mysql-test/suite/thread_pool/t/threadpool_shutdown.test
+++ b/mysql-test/suite/thread_pool/t/threadpool_shutdown.test
@@ -1,0 +1,79 @@
+# Start with thread_handling=pool-of-threads
+
+--source suite/thread_pool/include/have_pool_of_threads.inc
+
+# initialize data
+CREATE DATABASE db1;
+CREATE TABLE db1.t1 (
+    c1 int NOT NULL,
+    c2 int NOT NULL,
+    PRIMARY KEY (c1)
+);
+INSERT INTO db1.t1 (c1,c2) VALUES (1,11);
+INSERT INTO db1.t1 (c1,c2) VALUES (2,22);
+INSERT INTO db1.t1 (c1,c2) VALUES (3,33);
+
+connect(conn0,127.0.0.1,root,,db1);
+connect(conn1,127.0.0.1,root,,db1);
+
+connection conn0;
+START TRANSACTION;
+SELECT * FROM db1.t1 WHERE c1=2 FOR UPDATE;
+
+connection conn1;
+START TRANSACTION;
+SEND SELECT * FROM db1.t1 WHERE c1=2 LOCK IN SHARE MODE;
+
+connection default;
+--echo # Shutdown the server
+--source include/shutdown_mysqld.inc
+
+--echo # Start the server
+--source include/start_mysqld.inc
+
+--source suite/thread_pool/include/have_pool_of_threads.inc
+
+connect(conn2,127.0.0.1,root,,db1);
+connect(conn3,127.0.0.1,root,,db1);
+
+connection conn2;
+SEND SELECT benchmark(9999999999, md5('very long command 1'));
+
+connection conn3;
+SEND SELECT benchmark(9999999999, md5('very long command 2'));
+
+connection default;
+--echo # Shutdown the server
+--source include/shutdown_mysqld.inc
+
+--echo # Start the server
+--source include/start_mysqld.inc
+
+--source suite/thread_pool/include/have_pool_of_threads.inc
+
+connect(conn4,127.0.0.1,root,,db1);
+connect(conn5,127.0.0.1,root,,db1);
+
+connection conn4;
+SELECT * FROM db1.t1 WHERE c1=1;
+
+connection conn5;
+SELECT * FROM db1.t1 WHERE c1=2;
+
+connection default;
+--echo # Shutdown the server
+--source include/shutdown_mysqld.inc
+
+--echo # Start the server
+--source include/start_mysqld.inc
+
+--echo # Cleanup
+DROP TABLE db1.t1;
+DROP DATABASE db1;
+
+disconnect conn0;
+disconnect conn1;
+disconnect conn2;
+disconnect conn3;
+disconnect conn4;
+disconnect conn5;


### PR DESCRIPTION
Fix intermittent shutdown crashes if threadpool is enabled. Add MySQL test cases for threadpool shutdown.