### PR TITLE
modify the condition that a function supports parallel

### DIFF
--- a/sql/pq_condition.cc
+++ b/sql/pq_condition.cc
@@ -124,7 +124,7 @@ bool pq_not_support_func(Item_func *func) {
   }
 
   for (const char* funcname : NO_PQ_SUPPORTED_FUNC_ARGS) {
-    if (!strcmp(func->func_name(), funcname)) {
+    if (!strcmp(func->func_name(), funcname) && func->arg_count != 0) {
       return true;
     }
   }


### PR DESCRIPTION
1：增加对函数参数数量的限制。
2：解决mtr: main.histogram_equi_height,对应的SQL:EXPLAIN SELECT * FROM t1 WHERE col1 BETWEEN 0 AND RAND();