### PR TITLE
Fix MySQL test case for thread pool performance.

### DIFF
--- a/mysql-test/suite/funcs_1/r/is_columns_is.result
+++ b/mysql-test/suite/funcs_1/r/is_columns_is.result
@@ -316,7 +316,7 @@ def	information_schema	THREAD_POOL_GROUPS	IS_STALLED	8	0	NO	tinyint	NULL	NULL	3	
 def	information_schema	THREAD_POOL_GROUPS	QUEUE_LENGTH	6	0	NO	int	NULL	NULL	10	0	NULL	NULL	NULL	int(6)			select		
 def	information_schema	THREAD_POOL_GROUPS	STANDBY_THREADS	5	0	NO	int	NULL	NULL	10	0	NULL	NULL	NULL	int(6)			select		
 def	information_schema	THREAD_POOL_GROUPS	THREADS	3	0	NO	int	NULL	NULL	10	0	NULL	NULL	NULL	int(6)			select		
-def	information_schema	THREAD_POOL_QUEUES	CONNECTION_ID	4	NULL	YES	bigint	NULL	NULL	20	0	NULL	NULL	NULL	bigint(19) unsigned			select		
+def	information_schema	THREAD_POOL_QUEUES	CONNECTION_ID	4	0	NO	bigint	NULL	NULL	20	0	NULL	NULL	NULL	bigint(19) unsigned			select		
 def	information_schema	THREAD_POOL_QUEUES	GROUP_ID	1	0	NO	int	NULL	NULL	10	0	NULL	NULL	NULL	int(6)			select		
 def	information_schema	THREAD_POOL_QUEUES	POSITION	2	0	NO	int	NULL	NULL	10	0	NULL	NULL	NULL	int(6)			select		
 def	information_schema	THREAD_POOL_QUEUES	PRIORITY	3	0	NO	int	NULL	NULL	10	0	NULL	NULL	NULL	int(1)			select		

--- a/sql/conn_handler/connection_handler_manager.cc
+++ b/sql/conn_handler/connection_handler_manager.cc
@@ -191,11 +191,19 @@ bool Connection_handler_manager::init()
     DBUG_ASSERT(false);
   }
 
+  if (connection_handler == NULL)
+  {
+    // This is a static member function.
+    Per_thread_connection_handler::destroy();
+    return true;
+  }
+
   Connection_handler *extra_connection_handler=
     new (std::nothrow) Per_thread_connection_handler();
 
-  if (connection_handler == NULL || extra_connection_handler == NULL)
+  if (extra_connection_handler == NULL)
   {
+    delete connection_handler;
     // This is a static member function.
     Per_thread_connection_handler::destroy();
     return true;
@@ -207,6 +215,7 @@ bool Connection_handler_manager::init()
   if (m_instance == NULL)
   {
     delete connection_handler;
+    delete extra_connection_handler;
     // This is a static member function.
     Per_thread_connection_handler::destroy();
     return true;

--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -510,9 +510,6 @@ static void timeout_check(pool_timer_t *timer)
  
   Besides checking for stalls, timer thread is also responsible for terminating
   clients that have been idle for longer than wait_timeout seconds.
-
-  TODO: Let the timer sleep for long time if there is no work to be done.
-  Currently it wakes up rather often on and idle server.
 */
 
 static void* timer_thread(void *param)
@@ -895,8 +892,6 @@ end:
  
  The actual values were not calculated using any scientific methods.
  They just look right, and behave well in practice.
- 
- TODO: Should throttling depend on thread_pool_stall_limit?
 */
 static ulonglong microsecond_throttling_interval(thread_group_t *thread_group)
 {
@@ -1758,9 +1753,9 @@ void tp_set_threadpool_stall_limit(uint limit)
 void tp_scheduler_event_begin(THD* thd)
 {
   DBUG_ENTER("tp_scheduler_event_begin");
-  connection_t *connection = (connection_t *)thd->event_scheduler.data;
+  connection_t *connection = NULL;
 
-  if (thd == NULL || connection == NULL) {
+  if (thd == NULL || (connection = (connection_t *)thd->event_scheduler.data) == NULL) {
     DBUG_VOID_RETURN;
   }
 
@@ -1781,9 +1776,9 @@ void tp_scheduler_event_begin(THD* thd)
 void tp_scheduler_event_end(THD* thd)
 {
   DBUG_ENTER("tp_scheduler_event_end");
-  connection_t *connection = (connection_t *)thd->event_scheduler.data;
+  connection_t *connection = NULL;
 
-  if (thd == NULL || connection == NULL) {
+  if (thd == NULL || (connection = (connection_t *)thd->event_scheduler.data) == NULL) {
     DBUG_VOID_RETURN;
   }
 


### PR DESCRIPTION
1. Fix MySQL test case because of adding attribute MY_I_S_UNSIGNED for field CONNECTION_ID in table thread_pool_queues.
2. Fix two potential problems. The first one may lead to resource leak. The second one checks whether a pointer is a nullptr after it has already been dereferenced, the order is incorrect.