### PR TITLE
解决并行内存占用计算不正确的问题

### DIFF
--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -969,7 +969,7 @@ bool JOIN::optimize() {
   if (thd->m_suite_for_pq == PqConditionStatus::ENABLED)
   {
     // save temp table param for later PQ scan
-    saved_tmp_table_param = new (thd->pq_mem_root) Temp_table_param();
+    saved_tmp_table_param = new (thd->mem_root) Temp_table_param();
     if (!saved_tmp_table_param) return true;
 
     saved_tmp_table_param->pq_copy(tmp_table_param);


### PR DESCRIPTION
1：修改MTR: parallel_query.pq_memory_limit parallel_query.pq_kill_query parallel_query.pq_mq_error parallel_query.pq_worker_error parallel_query.pq_abort
2:执行show status like "PQ_memory_used";语句时，该语句不支持并行，但是判断该语句是否执行并行时，开辟了并行内存，导致显示结果不正确，把判断过程中用到的内存，改为普通内存。
fixes:#77
