### PR TITLE
Buffer pool page_hash_locks optimization

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -21111,13 +21111,11 @@ static MYSQL_SYSVAR_ULONGLONG(
     ulonglong{srv_buf_pool_chunk_unit_max},
     ulonglong{srv_buf_pool_chunk_unit_blk_sz});
 
-#if defined UNIV_DEBUG || defined UNIV_PERF_DEBUG
 static MYSQL_SYSVAR_ULONG(page_hash_locks, srv_n_page_hash_locks,
                           PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY,
                           "Number of rw_locks protecting buffer pool "
                           "page_hash. Rounded up to the next power of 2",
                           nullptr, nullptr, 16, 1, MAX_PAGE_HASH_LOCKS, 0);
-#endif /* defined UNIV_DEBUG || defined UNIV_PERF_DEBUG */
 
 // clang-format off
 static MYSQL_SYSVAR_BOOL(
@@ -22123,9 +22121,7 @@ static SYS_VAR *innobase_system_variables[] = {
     MYSQL_SYSVAR(merge_threshold_set_all_debug),
     MYSQL_SYSVAR(semaphore_wait_timeout_debug),
 #endif /* UNIV_DEBUG */
-#if defined UNIV_DEBUG || defined UNIV_PERF_DEBUG
     MYSQL_SYSVAR(page_hash_locks),
-#endif /* defined UNIV_DEBUG || defined UNIV_PERF_DEBUG */
     MYSQL_SYSVAR(status_output),
     MYSQL_SYSVAR(status_output_locks),
     MYSQL_SYSVAR(print_all_deadlocks),

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -108,7 +108,7 @@ constexpr ulint MAX_BUFFER_POOLS = (1 << MAX_BUFFER_POOLS_BITS);
 #define BUF_POOL_WATCH_SIZE (srv_n_purge_threads + 1)
 
 /** The maximum number of page_hash locks */
-constexpr ulint MAX_PAGE_HASH_LOCKS = 1024;
+constexpr ulint MAX_PAGE_HASH_LOCKS = 1048576;
 
 /** The buffer pools of the database */
 extern buf_pool_t *buf_pool_ptr;


### PR DESCRIPTION
1. Make system variable page_hash_locks configurable
2. Make the maximum value of system variable page_hash_locks larger