### PR TITLE
屏蔽main.subquery_mat_mixed_types用例

### DIFF
--- a/mysql-test/collections/disabled-pq-debug-kp.def
+++ b/mysql-test/collections/disabled-pq-debug-kp.def
@@ -9,3 +9,4 @@ main.ssl_crl_clients_valid  : BUG#111 origin code failed
 main.ssl_crl_crlpath  : BUG#111 origin code failed
 sys_vars.innodb_buffer_pool_size_basic  : BUG#111 origin code failed
 innodb.innodb_bug30113362  : BUG#111 pq code add
+main.subquery_mat_mixed_types  : BUG#111 pq code add

--- a/mysql-test/collections/disabled-pq-kp.def
+++ b/mysql-test/collections/disabled-pq-kp.def
@@ -9,3 +9,4 @@ main.ssl_crl_crlpath                              : BUG#111 skip example
 main.file_contents                                : BUG#111 skip example
 main.read_only_ddl                                : BUG#111 skip example
 main.log_buffered-big                             : BUG#111 skip example
+main.subquery_mat_mixed_types                     : BUG#111 skip example


### PR DESCRIPTION
屏蔽main.subquery_mat_mixed_types用例。由于执行计划不稳定，有时可以并行，有时不可以并行，导致执行结果不一致，原生就存在执行计划不稳定的问题。
fixes: #77 