### PR TITLE
[Issue#147]Fix the bug of threadpool shutdown may be incomplete.

### DIFF
--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -1028,13 +1028,12 @@ static void thread_group_close(thread_group_t *thread_group)
   DBUG_ENTER("thread_group_close");
 
   mysql_mutex_lock(&thread_group->mutex);
+  thread_group->shutdown = true;
   if (thread_group->thread_count == 0) 
   {
     mysql_mutex_unlock(&thread_group->mutex);
     DBUG_VOID_RETURN;
   }
-
-  thread_group->shutdown= true; 
 
   if (pipe(thread_group->shutdown_pipe))
   {


### PR DESCRIPTION
#147 In old code, when thread_count is zero we destroy the thread group. Then we move the destroy operation to a concentrated place to reduce delay. But we just return when thread_count is zero, which may lead to incompleted threadpool shutdown. In new code, we set shutdown flag before judging whether thread_count is zero to fix the bug.