### PR TITLE
禁止having后面带聚合函数的查询语句并行

### DIFF
--- a/mysql-test/suite/parallel_query/r/pq_having.result-pq
+++ b/mysql-test/suite/parallel_query/r/pq_having.result-pq
@@ -1,0 +1,248 @@
+drop database if exists pq_having_database;
+create database pq_having_database;
+use pq_having_database;
+DROP TABLE IF EXISTS `t1`;
+CREATE TABLE `t1`  (
+`fd1` int NOT NULL,
+`fd2` int NOT NULL  
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci ROW_FORMAT = Dynamic;
+INSERT INTO t1 VALUES(1, 1);
+INSERT INTO t1 VALUES(2, 2);
+INSERT INTO t1 VALUES(3, 3);
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+pq_having_database.t1	analyze	status	OK
+explain select fd1, avg(fd2) from t1 group by fd1 having avg(fd1) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (avg(`pq_having_database`.`t1`.`fd1`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having avg(fd1) > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having bit_and(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (bit_and(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having bit_and(fd2) > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having bit_or(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (bit_or(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having bit_or(fd2) > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having bit_xor(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (bit_xor(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having bit_xor(fd2) > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having count(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (count(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having count(fd2) > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having count(distinct fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using filesort
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (count(distinct `pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having count(distinct fd2) > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having group_concat(distinct fd2) is not null;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using filesort
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (group_concat(distinct `pq_having_database`.`t1`.`fd2` separator ',') is not null)
+select fd1, avg(fd2) from t1 group by fd1 having group_concat(distinct fd2) is not null;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, fd2, avg(fd2) from t1 group by fd1, fd2 having json_arrayagg(fd2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using filesort
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,`pq_having_database`.`t1`.`fd2` AS `fd2`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1`,`pq_having_database`.`t1`.`fd2` having (0 <> json_arrayagg(`pq_having_database`.`t1`.`fd2`))
+select fd1, fd2, avg(fd2) from t1 group by fd1, fd2 having json_arrayagg(fd2);
+fd1	fd2	avg(fd2)
+1	1	1.0000
+2	2	2.0000
+3	3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1, fd2 having json_object(fd1, fd2) is not null;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1`,`pq_having_database`.`t1`.`fd2` having (json_object(`pq_having_database`.`t1`.`fd1`,`pq_having_database`.`t1`.`fd2`) is not null)
+select fd1, avg(fd2) from t1 group by fd1, fd2 having json_object(fd1, fd2) is not null;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having std(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (std(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having std(fd2) > 0;
+fd1	avg(fd2)
+explain select fd1, avg(fd2) from t1 group by fd1 having stddev(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (std(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having stddev(fd2) > 0;
+fd1	avg(fd2)
+explain select fd1, avg(fd2) from t1 group by fd1 having stddev_pop(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (std(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having stddev_pop(fd2) > 0;
+fd1	avg(fd2)
+explain select fd1, avg(fd2) from t1 group by fd1 having stddev_samp(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (stddev_samp(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having stddev_samp(fd2) > 0;
+fd1	avg(fd2)
+explain select fd1, avg(fd2) from t1 group by fd1 having max(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (max(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having max(fd2) > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having min(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (min(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having min(fd2) > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having sum(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (sum(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having sum(fd2) > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having var_pop(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (variance(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having var_pop(fd2) > 0;
+fd1	avg(fd2)
+explain select fd1, avg(fd2) from t1 group by fd1 having var_samp(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (var_samp(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having var_samp(fd2) > 0;
+fd1	avg(fd2)
+explain select fd1, avg(fd2) from t1 group by fd1 having variance(fd2) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (variance(`pq_having_database`.`t1`.`fd2`) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having variance(fd2) > 0;
+fd1	avg(fd2)
+explain select fd1, avg(fd2) from t1 group by fd1 having max(fd1)/min(fd1) > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having ((max(`pq_having_database`.`t1`.`fd1`) / min(`pq_having_database`.`t1`.`fd1`)) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having max(fd1)/min(fd1) > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having max(fd1) + 1 > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having ((max(`pq_having_database`.`t1`.`fd1`) + 1) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having max(fd1) + 1 > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having fd1 + 1 > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	<gather2>	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Parallel execute (1 workers)
+2	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having ((`pq_having_database`.`t1`.`fd1` + 1) > 0)
+select fd1, avg(fd2) from t1 group by fd1 having fd1 + 1 > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2) from t1 group by fd1 having fd1 > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	<gather2>	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Parallel execute (1 workers)
+2	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (`pq_having_database`.`t1`.`fd1` > 0)
+select fd1, avg(fd2) from t1 group by fd1 having fd1 > 0;
+fd1	avg(fd2)
+1	1.0000
+2	2.0000
+3	3.0000
+explain select fd1, avg(fd2), max(fd1) from t1 group by fd1 having fd1 > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	<gather2>	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Parallel execute (1 workers)
+2	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)`,max(`pq_having_database`.`t1`.`fd1`) AS `max(fd1)` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (`pq_having_database`.`t1`.`fd1` > 0)
+select fd1, avg(fd2), max(fd1) from t1 group by fd1 having fd1 > 0;
+fd1	avg(fd2)	max(fd1)
+1	1.0000	1
+2	2.0000	2
+3	3.0000	3
+explain select fd1, avg(fd2), avg(fd1) as avg  from t1 group by fd1 having avg > 0;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using temporary
+Warnings:
+Note	1003	/* select#1 */ select `pq_having_database`.`t1`.`fd1` AS `fd1`,avg(`pq_having_database`.`t1`.`fd2`) AS `avg(fd2)`,avg(`pq_having_database`.`t1`.`fd1`) AS `avg` from `pq_having_database`.`t1` group by `pq_having_database`.`t1`.`fd1` having (`avg` > 0)
+select fd1, avg(fd2), avg(fd1) as avg from t1 group by fd1 having avg > 0;
+fd1	avg(fd2)	avg
+1	1.0000	1.0000
+2	2.0000	2.0000
+3	3.0000	3.0000
+drop table t1;
+drop database pq_having_database;

--- a/mysql-test/suite/parallel_query/t/pq_having.test
+++ b/mysql-test/suite/parallel_query/t/pq_having.test
@@ -1,0 +1,97 @@
+--source include/pq_test.inc
+--disable_warnings
+drop database if exists pq_having_database;
+--enable_warnings
+create database pq_having_database;
+use pq_having_database;
+
+--disable_warnings
+DROP TABLE IF EXISTS `t1`;
+--enable_warnings
+CREATE TABLE `t1`  (
+  `fd1` int NOT NULL,
+  `fd2` int NOT NULL  
+) ENGINE = InnoDB CHARACTER SET = utf8mb4 COLLATE = utf8mb4_0900_ai_ci ROW_FORMAT = Dynamic;
+
+INSERT INTO t1 VALUES(1, 1);
+INSERT INTO t1 VALUES(2, 2);
+INSERT INTO t1 VALUES(3, 3);
+analyze table t1;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having avg(fd1) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having avg(fd1) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having bit_and(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having bit_and(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having bit_or(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having bit_or(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having bit_xor(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having bit_xor(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having count(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having count(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having count(distinct fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having count(distinct fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having group_concat(distinct fd2) is not null;
+select fd1, avg(fd2) from t1 group by fd1 having group_concat(distinct fd2) is not null;
+
+explain select fd1, fd2, avg(fd2) from t1 group by fd1, fd2 having json_arrayagg(fd2);
+select fd1, fd2, avg(fd2) from t1 group by fd1, fd2 having json_arrayagg(fd2);
+
+explain select fd1, avg(fd2) from t1 group by fd1, fd2 having json_object(fd1, fd2) is not null;
+select fd1, avg(fd2) from t1 group by fd1, fd2 having json_object(fd1, fd2) is not null;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having std(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having std(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having stddev(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having stddev(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having stddev_pop(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having stddev_pop(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having stddev_samp(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having stddev_samp(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having max(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having max(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having min(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having min(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having sum(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having sum(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having var_pop(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having var_pop(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having var_samp(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having var_samp(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having variance(fd2) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having variance(fd2) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having max(fd1)/min(fd1) > 0;
+select fd1, avg(fd2) from t1 group by fd1 having max(fd1)/min(fd1) > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having max(fd1) + 1 > 0;
+select fd1, avg(fd2) from t1 group by fd1 having max(fd1) + 1 > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having fd1 + 1 > 0;
+select fd1, avg(fd2) from t1 group by fd1 having fd1 + 1 > 0;
+
+explain select fd1, avg(fd2) from t1 group by fd1 having fd1 > 0;
+select fd1, avg(fd2) from t1 group by fd1 having fd1 > 0;
+
+explain select fd1, avg(fd2), max(fd1) from t1 group by fd1 having fd1 > 0;
+select fd1, avg(fd2), max(fd1) from t1 group by fd1 having fd1 > 0;
+
+explain select fd1, avg(fd2), avg(fd1) as avg  from t1 group by fd1 having avg > 0;
+select fd1, avg(fd2), avg(fd1) as avg from t1 group by fd1 having avg > 0;
+
+drop table t1;
+drop database pq_having_database;


### PR DESCRIPTION
1.禁止having后面带聚合函数的查询语句并行
2.修改mtr:main.group_by, main.having,  main.view_grant, parallel_query.pq_group_by, main.func_math
3.新增mtr:pq_having
4:fixes: #142 
