### PR TITLE
解决查询语句带有常量聚合函数执行结果不对的问题

### DIFF
--- a/sql/sql_executor.cc
+++ b/sql/sql_executor.cc
@@ -6519,7 +6519,9 @@ bool change_to_use_tmp_fields(List<Item> &all_fields,
 #endif
     } else
       item_field = item;
-
+    if (item->type() == Item::SUM_FUNC_ITEM && item->const_item() && thd->parallel_exec) {
+      item_field = item;
+    }
     res_all_fields->push_back(item_field);
     /*
       Cf. comment explaining the reordering going on below in


### PR DESCRIPTION
1：解决查询语句带有常量聚合函数执行结果不对的问题，比如SELECT count(*) = max(a) FROM t1 WHERE c1='aaaa';;其中max(a)被优化后，变成了常量item.
2：对应MTR:innodb.instant_add_column_basic,main.type_bit_innodb
3：fixes: #142 