### PR TITLE
解决内存未初始化的问题

### DIFF
--- a/sql/sql_tmp_table.cc
+++ b/sql/sql_tmp_table.cc
@@ -445,7 +445,7 @@ Field *create_tmp_field(THD *thd, TABLE *table, Item *item, Item::Type type,
       DBUG_ASSERT(false);
       break;
   }
-  if (result != nullptr) {
+  if (result != nullptr && thd->parallel_exec) {
     result->extra_length = item->pq_extra_len(group);
   }
   return result;


### PR DESCRIPTION
1.解决内存未初始化的问题，由于字段长度计算错误，导致部分字段内容未设置
2.fixes:#136