### PR TITLE
valgrind失败用例main.func_aes修改

### DIFF
--- a/sql/sql_parallel.cc
+++ b/sql/sql_parallel.cc
@@ -835,6 +835,11 @@ err:
   pq_stack_reset();
 #endif
 
+  /* Clean up openssl errors. */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    ERR_remove_thread_state(0);
+#endif
+
   my_thread_end();
   /* s4: send last status to leader */
   PQ_worker_state status =


### PR DESCRIPTION
内存泄漏原因：openssl错误处理申请的内存需要在线程退出前进行释放，worker线程退出前未释放导致。
fixes:#77