### PR TITLE
resoleve the leader error in comparing the data returned by the worker

### DIFF
--- a/sql/sql_parallel.cc
+++ b/sql/sql_parallel.cc
@@ -625,8 +625,6 @@ PQ_exec_status make_pq_leader_plan(THD *thd) {
         join->qep_tab[i].set_position(nullptr);
       }
     }
-    destroy(tab->filesort);
-    tab->filesort = nullptr;
     join->m_root_iterator.reset();
     join->unit->m_root_iterator.reset();
 

--- a/storage/innobase/row/row0pread.cc
+++ b/storage/innobase/row/row0pread.cc
@@ -1495,9 +1495,14 @@ dberr_t Parallel_reader::Scan_ctx::create_contexts(const Ranges &ranges) {
   }
 
   size_t i{};
-
+  size_t split_num = 0;
+  if (ranges.size() > split_point) {
+    split_num = ranges.size() - split_point;
+  }
+  bool split;
   for (auto range : ranges) {
-    auto err = create_context(range, i >= split_point);
+    split = m_config.m_pq_reverse_scan ? i < split_num : i >= split_point;
+    auto err = create_context(range, split);
 
     if (err != DB_SUCCESS) {
       return (err);


### PR DESCRIPTION
1.修改leader在特定情况下无法比较worker返回的数据大小的问题
2.修改倒序遍历的情况下，区间二次切分顺序不对的问题。
2. fixes: #169 