### PR TITLE
并行ctrl+c 响应异常问题

### DIFF
--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -921,6 +921,11 @@ class THD : public MDL_context_owner,
   /* check first table. */
   uint pq_check_fields{0};
   uint pq_check_reclen{0};
+  
+  /* save PQ worker THDs. */
+  std::vector<THD*> pq_workers;
+  /* protects THD::pq_workers. */
+  mysql_mutex_t pq_lock_worker;
 
   /* Used to execute base64 coded binlog events in MySQL server */
   Relay_log_info *rli_fake;

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -1164,8 +1164,10 @@ bool SELECT_LEX_UNIT::ExecuteIteratorQuery(THD *thd) {
 
   thd->get_stmt_da()->reset_current_row_for_condition();
   if (m_root_iterator->Init()) {
-    /** for parallel scan, we should end the root iterator*/
-    if (thd->parallel_exec) m_root_iterator->End();
+    /** for parallel scan, we should end the pq iterator */
+    if (thd->parallel_exec && thd->pq_iterator) {
+      thd->pq_iterator->End();
+    }
     return true;
   }
 


### PR DESCRIPTION
1、分析并行查询执行计划，客户端ctrl+c mysql崩溃;
2、并行查询过程中，客户端ctrl+c无法快速停止查询。
fixes:#201