### PR TITLE
solve the problem of unstable execution plan

### DIFF
--- a/mysql-test/collections/disabled-pq-kp.def
+++ b/mysql-test/collections/disabled-pq-kp.def
@@ -8,4 +8,5 @@ main.file_contents                                      : BUG#000 origin code fa
 main.read_only_ddl                                      : BUG#000 origin code failed
 secondary_engine.cost_threshold                         : BUG#000 origin code failed
 sys_vars.innodb_buffer_pool_size_basic                  : BUG#000 origin code failed
+main.log_buffered-big                                   : BUG#000 origin code failed
 

--- a/mysql-test/r/explain_tree.result-pq
+++ b/mysql-test/r/explain_tree.result-pq
@@ -723,9 +723,9 @@ Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
 EXPLAIN ANALYZE SELECT * FROM t1 AS a JOIN t1 AS b ON a.a=b.b ORDER BY a.b+b.a LIMIT 3;
 EXPLAIN
--> Limit: 3 row(s)  (cost=0.00..0.00 rows=0) (actual time=N.NNN..N.NNN rows=0 loops=1)
-    -> Table scan on <temporary>  (cost=2.50..2.50 rows=0) (never executed)
-        -> Temporary table  (cost=2.50..2.50 rows=0) (actual time=N.NNN..N.NNN rows=0 loops=1)
+-> Limit: 3 row(s)  (cost=0.00..0.00 rows=0) (actual time=N.NNN..N.NNN rows=1 loops=1)
+    -> Table scan on <temporary>  (cost=2.50..2.50 rows=0) (actual time=N.NNN..N.NNN rows=1 loops=1)
+        -> Temporary table  (cost=2.50..2.50 rows=0) (actual time=N.NNN..N.NNN rows=1 loops=1)
             -> Parallel scan on <temporary>  (actual time=N.NNN..N.NNN rows=1 loops=1)
                 -> Limit: 3 row(s)  (actual time=N.NNN..N.NNN rows=1 loops=1)
                     -> Sort: `(a.b + b.a)`, limit input to 3 row(s) per chunk  (actual time=N.NNN..N.NNN rows=1 loops=1)

--- a/mysql-test/r/hash_join.result-pq
+++ b/mysql-test/r/hash_join.result-pq
@@ -491,10 +491,6 @@ COUNT_STAR > 0
 SELECT COUNT(*) FROM t2 WHERE (t2.i) IN (SELECT t1.i FROM t1);
 COUNT(*)
 1024
-SELECT COUNT_STAR > 0 FROM performance_schema.file_summary_by_event_name
-WHERE event_name LIKE '%hash_join%';
-COUNT_STAR > 0
-0
 DROP TABLE t1, t2;
 SET join_buffer_size = DEFAULT;
 SET optimizer_switch = DEFAULT;

--- a/mysql-test/t/hash_join.test
+++ b/mysql-test/t/hash_join.test
@@ -329,8 +329,10 @@ TRUNCATE performance_schema.file_summary_by_event_name;
 eval $hash_join_file_operations;
 SELECT COUNT(*) FROM t2 WHERE (t2.i) IN (SELECT t1.i FROM t1);
 --skip_if_hypergraph  # Does not use weedout, so does not need row ID, and thus does not spill to disk.
-eval $hash_join_file_operations;
-
+if (!$PQ_TEST)
+{
+  eval $hash_join_file_operations;
+}
 DROP TABLE t1, t2;
 SET join_buffer_size = DEFAULT;
 SET optimizer_switch = DEFAULT;

--- a/sql/records.cc
+++ b/sql/records.cc
@@ -582,6 +582,7 @@ int ParallelScanIterator::pq_error_code() {
 
 bool ParallelScanIterator::Init() {
   assert(current_thd == m_join->thd);
+  m_gather->waitReadEnd();
   if (m_gather->init() ||        /** cur innodb data,
                                      should be called first(will change dop based on
                                     split count) */
@@ -606,6 +607,7 @@ int ParallelScanIterator::Read() {
 }
 
 int ParallelScanIterator::End() {
+  m_gather->signalReadEnd();
   /** wait all workers to finish their execution */
   pq_wait_workers_finished();
   /** output error code */

--- a/sql/sql_parallel.h
+++ b/sql/sql_parallel.h
@@ -146,6 +146,9 @@ class Gather_operator {
   CODE_STATE **m_code_state;
   bool table_scan;
 
+ private:
+  std::mutex m_read_end_mutex;
+
  public:
   Gather_operator() = delete;
 
@@ -158,6 +161,10 @@ class Gather_operator {
   void end();
 
   void signalAll();
+
+  void signalReadEnd();
+
+  void waitReadEnd();
 };
 
 Gather_operator *make_pq_gather_operator(JOIN *join, QEP_TAB *tab, uint dop);


### PR DESCRIPTION
1：屏蔽原生valgrind失败用例main.log_buffered-big
2：解决在valgrind模式下main.explain_tree用例失败问题
问题原因：在执行EXPLAIN ANALYZE语句时，worker的执行计划中需要打印表中数据的行数，该行数有leader通过扫描表获取，在leader还没有完成扫描时，就返回了worker的执行计划，导致worker不能正确获取表的行数。
解决办法：在worker打印执行计划之前，等待leader扫描完成，leader扫描完成后，再获取worker的执行计划。
3：解决在valgrind模式下main.hash_join用例失败问题
问题原因：执行hashjoin过程中存在落盘和不落盘两种情况，从而导致统计结果不确定。由于多线程并行时，切分的是build表，导致每个线程需要构建的行数变小，在valgrind模式下，每个worker获取到的行数不确定，当一个worker获取到所有的数据后，会导致落盘，在每个worker都获取到数据的情况下，不会落盘，从而导致落盘的信息不确定。
解决办法：在并行模式下，不去获取是否落盘的信息。
